### PR TITLE
Improve classic warlock precision

### DIFF
--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -288,6 +288,7 @@ tinsert(HarmSpells.WARLOCK, 5782)       -- Fear (30 yards)
 if not isRetail then
     tinsert(HarmSpells.WARLOCK, 172)    -- Corruption (30 yards, level 4, rank 1)
     tinsert(HarmSpells.WARLOCK, 348)    -- Immolate (30 yards, level 1, rank 1)
+    tinsert(HarmSpells.WARLOCK, 17877)  -- Shadowburn (Destruction) (20 yards)
 end
 
 tinsert(ResSpells.WARLOCK, 20707)   -- Soulstone (40 yards)


### PR DESCRIPTION
Shadowburn and Fear are both 20/22/24 yd spells in classic, but they benefit from different range increase talents. Adding Shadowburn improves accuracy for most warlocks.