### PR TITLE
Improve classic warlock precision

### DIFF
--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -41,7 +41,7 @@ License: Public Domain
 -- @class file
 -- @name LibRangeCheck-2.0
 local MAJOR_VERSION = "LibRangeCheck-2.0"
-local MINOR_VERSION = tonumber(("$Revision: 214 $"):match("%d+")) + 100000
+local MINOR_VERSION = tonumber(("$Revision: 215 $"):match("%d+")) + 100000
 
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end
@@ -289,6 +289,7 @@ if not isRetail then
     tinsert(HarmSpells.WARLOCK, 172)    -- Corruption (30 yards, level 4, rank 1)
     tinsert(HarmSpells.WARLOCK, 348)    -- Immolate (30 yards, level 1, rank 1)
     tinsert(HarmSpells.WARLOCK, 17877)  -- Shadowburn (Destruction) (20 yards)
+    tinsert(HarmSpells.WARLOCK, 18223)  -- Curse of Exhaustion (Affliction) (30/33/36/35/38/42 yards)
 end
 
 tinsert(ResSpells.WARLOCK, 20707)   -- Soulstone (40 yards)


### PR DESCRIPTION
Glyph of Curse of Exhaustion in WotLK increases the range of Curse of Exhaustion up to a maximum of 42y.