### PR TITLE
Add time based caching by UnitGUID

### DIFF
--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -72,6 +72,7 @@ local UnitCanAttack = UnitCanAttack
 local UnitCanAssist = UnitCanAssist
 local UnitExists = UnitExists
 local UnitIsUnit = UnitIsUnit
+local UnitGUID = UnitGUID
 local UnitIsDeadOrGhost = UnitIsDeadOrGhost
 local CheckInteractDistance = CheckInteractDistance
 local IsSpellInRange = IsSpellInRange
@@ -683,7 +684,8 @@ end
 
 -- returns minRange, maxRange  or nil
 local function getRange(unit, checkerList)
-    local cacheItem = rangeCache[unit]
+    local guid = UnitGUID(unit)
+    local cacheItem = rangeCache[guid]
     if cacheItem then
         return cacheItem.minRange, cacheItem.maxRange
     end
@@ -709,7 +711,7 @@ local function getRange(unit, checkerList)
         result.minRange = checkerList[lo].range
         result.maxRange = checkerList[lo - 1].range
     end
-    rangeCache[unit] = result
+    rangeCache[guid] = result
     return result.minRange, result.maxRange
 end
 

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -682,11 +682,17 @@ local function resetRangeCache()
     wipe(rangeCache)
 end
 
+local function invalidateRangeCache()
+    for _, v in pairs(rangeCache) do
+        v.valid = false
+    end
+end
+
 -- returns minRange, maxRange  or nil
 local function getRange(unit, checkerList)
     local guid = UnitGUID(unit)
     local cacheItem = rangeCache[guid]
-    if cacheItem then
+    if cacheItem and cacheItem.valid then
         return cacheItem.minRange, cacheItem.maxRange
     end
     
@@ -700,7 +706,7 @@ local function getRange(unit, checkerList)
             hi = mid - 1
         end
     end
-    local result = {}
+    local result = cacheItem or {}
     if lo > #checkerList then
         result.minRange = 0
         result.maxRange = checkerList[#checkerList].range
@@ -711,6 +717,7 @@ local function getRange(unit, checkerList)
         result.minRange = checkerList[lo].range
         result.maxRange = checkerList[lo - 1].range
     end
+    result.valid = true
     rangeCache[guid] = result
     return result.minRange, result.maxRange
 end
@@ -1532,7 +1539,7 @@ function lib:activate()
             frame.elapsedSiceCacheReset = frame.elapsedSiceCacheReset + elapsed
             if frame.elapsedSiceCacheReset > 0.1 then
                 frame.elapsedSiceCacheReset = 0
-                resetRangeCache()
+                invalidateRangeCache()
             end
         end)
 

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -1049,7 +1049,8 @@ function lib:GetRange(unit, checkVisible, noItems)
 
     local currentTime = GetTime()
     local guid = UnitGUID(unit)
-    local cacheItem = rangeCache[guid]
+    local cacheKey = guid .. (noItems and "-1" or "-0")
+    local cacheItem = rangeCache[cacheKey]
     if cacheItem and cacheItem.updateTime + self.getRangeThrottle > currentTime then
         return cacheItem.minRange, cacheItem.maxRange
     end
@@ -1079,7 +1080,7 @@ function lib:GetRange(unit, checkVisible, noItems)
     end
 
     result.updateTime = currentTime
-    rangeCache[guid] = result
+    rangeCache[cacheKey] = result
     return result.minRange, result.maxRange
 end
 

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -1466,19 +1466,34 @@ function lib:updateMeasurements()
 end
 
 local debugprofilestop = debugprofilestop
-function lib:speedTest(numIterations)
-    resetRangeCache()
+function lib:speedTest(numBatches, numIterationsPerBatch)
     if not UnitExists("target") then
         print(MAJOR_VERSION .. ": Invalid unit, cannot check")
         return
     end
-    numIterations = numIterations or 10000
-    local start = debugprofilestop()
-    for i = 1, numIterations do
-        self:getRange("target")
+
+    numBatches = numBatches or 10000
+    numIterationsPerBatch = numIterationsPerBatch or 1
+
+    local min, max, total = 999999, 0, 0
+    for b = 1, numBatches do
+        resetRangeCache()
+        local start = debugprofilestop()
+        for i = 1, numIterationsPerBatch do
+            self:getRange("target")
+        end
+        local duration = debugprofilestop() - start
+
+        if duration < min then min = duration end
+        if duration > max then max = duration end
+        total = total + duration
     end
-    local duration = debugprofilestop() - start
-    print("numIterations: " .. tostring(numIterations) .. ", time: " .. tostring(duration))
+
+    local minRange, maxRange = self:getRange("target");
+
+    print(string.format("SpeedTest: numBatches = %d, numIterationsPerBatch = %d", numBatches, numIterationsPerBatch))
+    print(string.format("  Range: min = %d, max = %d", minRange, maxRange))
+    print(string.format("  Time per batch: min = %f, max = %f, total = %f, avg = %f", min, max, total, total/numBatches))
 end
 
 -- >> DEBUG STUFF

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -1084,7 +1084,7 @@ end
 -- @param unit the target unit to check range to.
 -- @param checkVisible if set to true, then a UnitIsVisible check is made, and **nil** is returned if the unit is not visible
 -- @param noItems if set to true, no items and only spells are being used for the range check
--- @param maxCacheAge the timespan a cached range value is considered valid (default 0.1 seconds, maximun 1 second)
+-- @param maxCacheAge the timespan a cached range value is considered valid (default 0.1 seconds, maximum 1 second)
 -- @return **minRange**, **maxRange** pair if a range estimate could be determined, **nil** otherwise. **maxRange** is **nil** if **unit** is further away than the highest possible range we can check.
 -- Includes checks for unit validity and friendly/enemy status.
 -- @usage

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -693,11 +693,13 @@ local function invalidateRangeCache(elapsed)
     end
 end
 
+local getRangeThrottle = 0.1
+
 -- returns minRange, maxRange  or nil
 local function getRange(unit, checkerList)
     local guid = UnitGUID(unit)
     local cacheItem = rangeCache[guid]
-    if cacheItem and cacheItem.timeSinceUpdate <= 0.1 then
+    if cacheItem and cacheItem.timeSinceUpdate <= getRangeThrottle then
         return cacheItem.minRange, cacheItem.maxRange
     end
 
@@ -1084,6 +1086,10 @@ function lib:GetRange(unit, checkVisible, noItems)
     else
         return getRange(unit, self.miscRC)
     end
+end
+
+function lib:SetGetRangeThrottle(timespan)
+    getRangeThrottle = timespan
 end
 
 -- keep this for compatibility

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -1033,7 +1033,7 @@ end
 -- @param unit the target unit to check range to.
 -- @param checkVisible if set to true, then a UnitIsVisible check is made, and **nil** is returned if the unit is not visible
 -- @param noItems if set to true, no items and only spells are being used for the range check
--- @param maxCacheAge the timespan a cached range value is considered valid (default 0.1 seconds)
+-- @param maxCacheAge the timespan a cached range value is considered valid (default 0.1 seconds, maximun 1 second)
 -- @return **minRange**, **maxRange** pair if a range estimate could be determined, **nil** otherwise. **maxRange** is **nil** if **unit** is further away than the highest possible range we can check.
 -- Includes checks for unit validity and friendly/enemy status.
 -- @usage
@@ -1050,6 +1050,7 @@ function lib:GetRange(unit, checkVisible, noItems, maxCacheAge)
     end
 
     maxCacheAge = maxCacheAge or 0.1;
+    maxCacheAge = maxCacheAge > 1 and 1 or maxCacheAge;
 
     local currentTime = GetTime()
     local guid = UnitGUID(unit)

--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -1527,8 +1527,13 @@ function lib:activate()
         local frame = CreateFrame("Frame")
         self.cacheResetFrame = frame
 
-        frame:SetScript("OnUpdate", function()
-            resetRangeCache()
+        frame.elapsedSiceCacheReset = 0
+        frame:SetScript("OnUpdate", function(_, elapsed)
+            frame.elapsedSiceCacheReset = frame.elapsedSiceCacheReset + elapsed
+            if frame.elapsedSiceCacheReset > 0.1 then
+                frame.elapsedSiceCacheReset = 0
+                resetRangeCache()
+            end
         end)
 
         frame:Show()


### PR DESCRIPTION
Implements a caching mechanism that builds up a table with cached range values as well as the time of the last update for the GUID of each requested unit.
This addition is required to extend the Range check of WeakAuras to handle multiple units (see WeakAuras/WeakAuras2#3640).

The cache entries are valid for a specific time (default is 100ms) which can be set via SetGetRangeThrottle.
If a cache entry is older than 5 seconds it is discarded to avoid a memory leak.

Points that I think need to be discussed here are:
1. Is the method of resetting the cache I used good?
2. Is it a good idea that the cache entries are alive for more than one frame (time based)?

(If you look at the commits, you see that I'm not quite sure what's the best approach :D)