### PR TITLE
Increase minor version number for compatibility

### DIFF
--- a/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
+++ b/LibRangeCheck-2.0/LibRangeCheck-2.0.lua
@@ -41,7 +41,7 @@ License: Public Domain
 -- @class file
 -- @name LibRangeCheck-2.0
 local MAJOR_VERSION = "LibRangeCheck-2.0"
-local MINOR_VERSION = tonumber(("$Revision: 217 $"):match("%d+")) + 100000
+local MINOR_VERSION = tonumber(("$Revision: 217 $"):match("%d+")) + 10000000000000
 
 local lib, oldminor = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
 if not lib then return end


### PR DESCRIPTION
Many addons are still using the older, official version of LibRangeCheck-2.0. Despite being less up to date, it is considered newer by LibStub because of its minor version number.

The official version has these lines:
```lua
local MAJOR_VERSION = "LibRangeCheck-2.0"
local MINOR_VERSION = 10000000000001 -- mistakes were made...
```

This addon has [these lines](https://github.com/WeakAuras/LibRangeCheck-2.0/blob/master/LibRangeCheck-2.0/LibRangeCheck-2.0.lua#L44):
```lua
local MAJOR_VERSION = "LibRangeCheck-2.0"
local MINOR_VERSION = tonumber(("$Revision: 217 $"):match("%d+")) + 100000
```

The problem is that the older, official versions are considered more up to date (10000000000001 > 100217), when actually they should be superseded. If this old version of LibRangeCheck-2.0 is loaded before a newer version, then the newer version is ignored.

Here are a couple examples of addons that use the older, official version of LibRangeCheck-2.0:

- [LibRangeCheck-2.0](https://www.wowace.com/projects/librangecheck-2-0) itself.
- [NeatPlates](https://www.curseforge.com/wow/addons/neatplates)
- [RangeDisplay](https://www.curseforge.com/wow/addons/range-display)

To be clear, the old version still works correctly, but is less precise. If I install both RangeDisplay and WeakAuras, then RangeDisplay will load first and both addons will use the inferior version of this library. This has been causing some popular addons (like WeakAuras and ElvUI) to be using unexpectedly imprecise range checking for certain users.